### PR TITLE
Add IntelliJ IDEA directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # BlueJ files
 *.ctxt
 
+# idea
+.idea/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 


### PR DESCRIPTION
This commit updates the .gitignore file to include the .idea/ directory, which is used by IntelliJ IDEA for project-specific settings. This ensures that these files are not tracked by git and prevents unnecessary clutter in the repository.